### PR TITLE
Simplify _metronome_modules_list() in _common.sh

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -21,9 +21,7 @@ ynh_metronome_ensure_module_is_enabled() {
 }
 
 _metronome_modules_list() {
-	grep -Ev '^\s*--' /etc/metronome/metronome.cfg.lua \
-	 | sed -n '/^modules_enabled = {$/,/^\s*};$/p' \
-	 | grep '\s*"' | sed -r 's/^\s*"([^"]+)";.*/\1/'
+	sed -n '/^modules_enabled = {$/,/^\s*\w/{/^\s*--/!{s#^\s*"\([^"]*\)".*#\1#p}}' /etc/metronome/metronome.cfg.lua	
 }
 
 _metronome_module_add() {


### PR DESCRIPTION
I'm not a yunohost user, but needed a list of metronome modules elsewhere. Thought I'd share my code golf solution. Results in the exact same output as the code before in my case. However, please test. Takes a little less forking as it just uses sed.